### PR TITLE
Updated version from 3.17.2 to 3.18.4

### DIFF
--- a/DistroLauncher/DistroSpecial.h
+++ b/DistroLauncher/DistroSpecial.h
@@ -27,6 +27,6 @@ namespace DistroSpecial
 	const std::wstring commandLineDeleteUSer = L"/usr/sbin/deluser --remove-home ";
 	const std::wstring commandLineQueryUID = L"/usr/bin/id -u ";
 	const PCWSTR commandLineDeleteResolvConf = L"/bin/rm /etc/resolv.conf";
-	const TCHAR UserlandDownloadURL[] = _T("https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-minirootfs-3.17.2-x86_64.tar.gz");
-	const std::wstring UserlandChecksum = L"b10fc6a33e462b9ccf704436071771051728d30f5d8b48adcddb9523c4c45328";
+	const TCHAR UserlandDownloadURL[] = _T("https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-minirootfs-3.18.4-x86_64.tar.gz");
+	const std::wstring UserlandChecksum = L"C59D5203BC6B8B6EF81F3F6B63E32C28D6E47BE806BA8528F8766A4CA506C7BA";
 }


### PR DESCRIPTION
Just as the title suggests, I've changed the URL (and the checksum accordingly) to point to the latest version of the Alpine mini rootfs; which is as of the time of writing version 3.18.4 released on 2023-09-28